### PR TITLE
Update tpm2_util.c

### DIFF
--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -1279,7 +1279,7 @@ void tpm2_util_tpm2_nv_to_yaml(TPM2B_NV_PUBLIC *nv_public, UINT8 *data, UINT16 s
         memcpy(&v, data, sizeof(UINT64));
         v = be64toh(v);
         print_yaml_indent(indent);
-        tpm2_tool_output("counter: %lu\n", v);
+        tpm2_tool_output("counter: %llu\n", v);
         break;
     case TPM2_NT_BITS:
         memcpy(&v, data, sizeof(UINT64));


### PR DESCRIPTION
Fix format: %lu expects argument of type long unsigned int, but argument 2 has type UINT64 (long long unsigned int)

Signed-off-by: Angelo Giovinazzo [sephiroth.a17@gmail.com](https://github.com/tpm2-software/tpm2-tools/pull/sephiroth.a17@gmail.com)